### PR TITLE
Adding support for sub-tests

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -48,12 +48,19 @@ func RunIntegrationTests(fixture *IntegrationTestFixture) {
 //	- The output has the correct number of items
 //	- Run any user-supplied assertions over the output
 func validateTerraformOutput(fixture *IntegrationTestFixture, output TerraformOutput) {
-	validateTerraformOutputCount(fixture, output)
-	validateTerraformOutputKeyValues(fixture, output)
+	fixture.GoTest.Run("Terraform Output Count", func(t *testing.T) {
+		validateTerraformOutputCount(fixture, output)
+	})
+
+	fixture.GoTest.Run("Terraform Output Key Values", func(t *testing.T) {
+		validateTerraformOutputKeyValues(fixture, output)
+	})
 
 	// run user-provided assertions over the TF output
-	for _, outputAssertion := range fixture.TfOutputAssertions {
-		outputAssertion(fixture.GoTest, output)
+	for i, outputAssertion := range fixture.TfOutputAssertions {
+		fixture.GoTest.Run(fmt.Sprintf("Custom Validation Function (%d)", i), func(t *testing.T) {
+			outputAssertion(fixture.GoTest, output)
+		})
 	}
 }
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -67,7 +67,7 @@ func validateTerraformOutput(fixture *IntegrationTestFixture, output TerraformOu
 // Validates that the terraform output contains the expected number of items
 func validateTerraformOutputCount(t *testing.T, fixture *IntegrationTestFixture, output TerraformOutput) {
 	if len(output) != fixture.ExpectedTfOutputCount {
-		t.Errorf(
+		t.Fatalf(
 			"Output unexpectedly had %d entries instead of %d",
 			len(output),
 			fixture.ExpectedTfOutputCount,
@@ -85,14 +85,14 @@ func validateTerraformOutputKeyValues(t *testing.T, fixture *IntegrationTestFixt
 	for expectedKey, expectedValue := range fixture.ExpectedTfOutput {
 		actualValue, isFound := output[expectedKey]
 		if !isFound {
-			fixture.GoTest.Errorf("Output unexpectedly did not contain key %s", expectedKey)
+			fixture.GoTest.Fatalf("Output unexpectedly did not contain key %s", expectedKey)
 		}
 
 		expectedAsJSON := jsonOrFail(fixture, expectedValue)
 		actualAsJSON := jsonOrFail(fixture, actualValue)
 
 		if expectedAsJSON != actualAsJSON {
-			t.Errorf(
+			t.Fatalf(
 				"Output value for '%s' was expected to be '%s' but was '%s'",
 				expectedKey,
 				expectedAsJSON,

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -49,29 +49,29 @@ func RunIntegrationTests(fixture *IntegrationTestFixture) {
 //	- Run any user-supplied assertions over the output
 func validateTerraformOutput(fixture *IntegrationTestFixture, output TerraformOutput) {
 	fixture.GoTest.Run("Terraform Output Count", func(t *testing.T) {
-		validateTerraformOutputCount(fixture, output)
+		validateTerraformOutputCount(t, fixture, output)
 	})
 
 	fixture.GoTest.Run("Terraform Output Key Values", func(t *testing.T) {
-		validateTerraformOutputKeyValues(fixture, output)
+		validateTerraformOutputKeyValues(t, fixture, output)
 	})
 
 	// run user-provided assertions over the TF output
 	for i, outputAssertion := range fixture.TfOutputAssertions {
 		fixture.GoTest.Run(fmt.Sprintf("Custom Validation Function (%d)", i), func(t *testing.T) {
-			outputAssertion(fixture.GoTest, output)
+			outputAssertion(t, output)
 		})
 	}
 }
 
 // Validates that the terraform output contains the expected number of items
-func validateTerraformOutputCount(fixture *IntegrationTestFixture, output TerraformOutput) {
+func validateTerraformOutputCount(t *testing.T, fixture *IntegrationTestFixture, output TerraformOutput) {
 	if len(output) != fixture.ExpectedTfOutputCount {
-		fixture.GoTest.Fatal(fmt.Errorf(
+		t.Errorf(
 			"Output unexpectedly had %d entries instead of %d",
 			len(output),
 			fixture.ExpectedTfOutputCount,
-		))
+		)
 	}
 }
 
@@ -81,23 +81,23 @@ func validateTerraformOutputCount(fixture *IntegrationTestFixture, output Terraf
 //	- Handles comparison of generic data types automatically
 //	- Handles differences in key ordering for maps
 //	- Handles all handling of generics, which is tricky in Go
-func validateTerraformOutputKeyValues(fixture *IntegrationTestFixture, output TerraformOutput) {
+func validateTerraformOutputKeyValues(t *testing.T, fixture *IntegrationTestFixture, output TerraformOutput) {
 	for expectedKey, expectedValue := range fixture.ExpectedTfOutput {
 		actualValue, isFound := output[expectedKey]
 		if !isFound {
-			fixture.GoTest.Fatal(fmt.Errorf("Output unexpectedly did not contain key %s", expectedKey))
+			fixture.GoTest.Errorf("Output unexpectedly did not contain key %s", expectedKey)
 		}
 
 		expectedAsJSON := jsonOrFail(fixture, expectedValue)
 		actualAsJSON := jsonOrFail(fixture, actualValue)
 
 		if expectedAsJSON != actualAsJSON {
-			fixture.GoTest.Fatal(fmt.Errorf(
+			t.Errorf(
 				"Output value for '%s' was expected to be '%s' but was '%s'",
 				expectedKey,
 				expectedAsJSON,
 				actualAsJSON,
-			))
+			)
 		}
 	}
 }

--- a/unit/unit.go
+++ b/unit/unit.go
@@ -166,7 +166,7 @@ func validatePlanResourceKeyValues(t *testing.T, fixture *UnitTestFixture, plan 
 	theExpectedPlanAsMap := resourceDescriptionToMap(fixture.ExpectedResourceAttributeValues)
 
 	if err := verifyTargetsExistInMap(theRealPlanAsMap, theExpectedPlanAsMap, ""); err != nil {
-		t.Fatal("", err)
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [N/A] I have updated the documentation accordingly.
* [NA] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3 


## What is the new behavior?
-------------------------------------
- Subtests are used to run all tests, not just fail on the first test that fails

## Does this introduce a breaking change?
-------------------------------------
- [NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->