### PR TITLE
Allow skipping terraform init on already initialized working directory

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -23,6 +23,7 @@ type TerraformOutputValidation func(goTest *testing.T, output TerraformOutput)
 type IntegrationTestFixture struct {
 	GoTest                *testing.T                  // Go test harness
 	TfOptions             *terraform.Options          // Terraform options
+	SkipInit              bool                        // Skip running `terraform init` command when the working directory is already initialized
 	ExpectedTfOutputCount int                         // Expected # of resources that Terraform should create
 	ExpectedTfOutput      TerraformOutput             // Expected Terraform Output
 	TfOutputAssertions    []TerraformOutputValidation // user-defined plan assertions
@@ -30,12 +31,14 @@ type IntegrationTestFixture struct {
 
 // RunIntegrationTests Executes terraform lifecycle events and verifies the correctness of the resulting resources.
 // The following actions are coordinated:
-//	- Run `terraform init`
+//	- Optionally run `terraform init`
 //	- Run `terraform output`
 //	- Validate outputs
 //	- Run user-supplied validation of outputs
 func RunIntegrationTests(fixture *IntegrationTestFixture) {
-	terraform.Init(fixture.GoTest, fixture.TfOptions)
+	if !fixture.SkipInit {
+		terraform.Init(fixture.GoTest, fixture.TfOptions)
+	}
 	output := terraform.OutputAll(fixture.GoTest, fixture.TfOptions)
 	validateTerraformOutput(fixture, TerraformOutput(output))
 }


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES/NO] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [YES/NO/NA] I have added tests to cover my changes.
* [YES/NO/NA] All new and existing tests passed.
* [YES/NO/NA] My code follows the code style of this project.
* [YES/NO/NA] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
When running _post-deployment integration test_ on an already initialized working directory, Terraform can detect backend configuration changes and ask to migrate the backend.

## What is the new behavior?
-------------------------------------
Adds and optional `SkipInit` arg so that the integration test only call `terraform output`.

## Does this introduce a breaking change?
-------------------------------------
- NO
