### PR TITLE
Add terraform command output validations

### DIFF
--- a/samples/azure/main.tf
+++ b/samples/azure/main.tf
@@ -27,7 +27,12 @@ variable "resource_group_name" {
 variable "resource_group_location" {
   type        = string
   default     = "Central US"
-  description = "Name of resource group to create"
+  description = "Location of resource group to create"
+
+  validation {
+    condition     = can(regex("US", var.resource_group_location))
+    error_message = "The resource group must be in the US, containing \"US\"."
+  }
 }
 
 

--- a/samples/azure/tests/unit/unit_test.go
+++ b/samples/azure/tests/unit/unit_test.go
@@ -2,10 +2,8 @@ package unittest
 
 import (
 	"samples/azure/tests"
-	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/hashicorp/terraform-json"
 	"github.com/microsoft/terratest-abstraction/unit"
 )
@@ -80,32 +78,6 @@ func TestPlanOutputs(t *testing.T) {
 				change := plan.OutputChanges["resource_group_name"]
 				if change.After != "MyTestResourceGroup" {
 					t.Fatal("output validation failed")
-				}
-			},
-		},
-	}
-
-	unit.RunUnitTests(&testFixture)
-}
-
-func TestTerraformCommandStdout(t *testing.T) {
-
-	testFixture := unit.UnitTestFixture{
-		GoTest: t,
-		TfOptions: &terraform.Options{
-			TerraformDir: "../../",
-			Upgrade:      true,
-			Vars: map[string]interface{}{
-				"resource_group_location": "Canada Central",
-			},
-		},
-		CommandStdoutAssertions: []unit.TerraformCommandStdoutValidation{
-			func(t *testing.T, output string, err error) {
-				if err == nil {
-					t.Fatal("should err")
-				}
-				if !strings.Contains(output, "Invalid value for variable") {
-					t.Fatal("should contain 'Invalid value for variable'")
 				}
 			},
 		},

--- a/samples/azure/tests/unit/unit_test.go
+++ b/samples/azure/tests/unit/unit_test.go
@@ -2,8 +2,10 @@ package unittest
 
 import (
 	"samples/azure/tests"
+	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/hashicorp/terraform-json"
 	"github.com/microsoft/terratest-abstraction/unit"
 )
@@ -78,6 +80,32 @@ func TestPlanOutputs(t *testing.T) {
 				change := plan.OutputChanges["resource_group_name"]
 				if change.After != "MyTestResourceGroup" {
 					t.Fatal("output validation failed")
+				}
+			},
+		},
+	}
+
+	unit.RunUnitTests(&testFixture)
+}
+
+func TestTerraformCommandStdout(t *testing.T) {
+
+	testFixture := unit.UnitTestFixture{
+		GoTest: t,
+		TfOptions: &terraform.Options{
+			TerraformDir: "../../",
+			Upgrade:      true,
+			Vars: map[string]interface{}{
+				"resource_group_location": "Canada Central",
+			},
+		},
+		CommandStdoutAssertions: []unit.TerraformCommandStdoutValidation{
+			func(t *testing.T, output string, err error) {
+				if err == nil {
+					t.Fatal("should err")
+				}
+				if !strings.Contains(output, "Invalid value for variable") {
+					t.Fatal("should contain 'Invalid value for variable'")
 				}
 			},
 		},

--- a/unit/testing-tf/main.tf
+++ b/unit/testing-tf/main.tf
@@ -11,6 +11,19 @@ terraform {
 provider "random" {
 }
 
+variable "length" {
+  type    = number
+  default = 16
+  validation {
+    condition     = var.length == 16
+    error_message = "Random string length must be 16."
+  }
+}
+
 resource "random_string" "s" {
-  length = 16
+  length = var.length
+}
+
+output "random_string_result" {
+  value = random_string.s.result
 }

--- a/unit/unit.go
+++ b/unit/unit.go
@@ -71,9 +71,13 @@ func RunUnitTests(fixture *UnitTestFixture) {
 		fixture.GoTest,
 		fixture.TfOptions,
 		terraform.FormatArgs(fixture.TfOptions, "plan", "-input=false", "-out", tfPlanFilePath)...)
-	if err != nil {
+	if err != nil && fixture.CommandStdoutAssertions == nil {
+		fixture.GoTest.Fatal(err)
+	}
+	if fixture.CommandStdoutAssertions != nil {
 		validateTerraformCommandStdout(fixture, output, err)
-	} else {
+	}
+	if err == nil {
 		validateTerraformPlanFile(fixture, tfPlanFilePath)
 	}
 }

--- a/unit/unit_test.go
+++ b/unit/unit_test.go
@@ -1,6 +1,7 @@
 package unit
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -8,11 +9,10 @@ import (
 
 // the workspace cannot be deleted in the case that the "before" workspace is the same
 // as the one used for the test. If this test passes, then the behavior is correct
-func TestSupportForUnitTestWitNoWorkspaceChange(t *testing.T) {
+func TestSupportForUnitTestWithNoWorkspaceChange(t *testing.T) {
 	tfOptions := &terraform.Options{
 		TerraformDir: "testing-tf/",
 		Upgrade:      true,
-		Vars:         map[string]interface{}{},
 	}
 
 	testFixture := UnitTestFixture{
@@ -21,6 +21,33 @@ func TestSupportForUnitTestWitNoWorkspaceChange(t *testing.T) {
 		ExpectedResourceCount:           1,
 		ExpectedResourceAttributeValues: nil,
 		Workspace:                       "default",
+	}
+
+	RunUnitTests(&testFixture)
+}
+
+func TestTerraformCommandStdout(t *testing.T) {
+	tfOptions := &terraform.Options{
+		TerraformDir: "testing-tf/",
+		Upgrade:      true,
+		Vars: map[string]interface{}{
+			"length": 15,
+		},
+	}
+
+	testFixture := UnitTestFixture{
+		GoTest:    t,
+		TfOptions: tfOptions,
+		CommandStdoutAssertions: []TerraformCommandStdoutValidation{
+			func(t *testing.T, output string, err error) {
+				if err == nil {
+					t.Fatal("should err")
+				}
+				if !strings.Contains(output, "Invalid value for variable") {
+					t.Fatal("should contain 'Invalid value for variable'")
+				}
+			},
+		},
 	}
 
 	RunUnitTests(&testFixture)


### PR DESCRIPTION
## All Submissions:
-------------------------------------
* [YES] Have you followed the guidelines in our Contributing [document](./CONTRIBUTING.md)?
* [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
* [YES] I have updated the documentation accordingly.
* [YES] I have added tests to cover my changes.
* [YES] All new and existing tests passed.
* [YES] My code follows the code style of this project.
* [YES] I ran lint checks locally prior to submission.
* [YES] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

## What is the current behavior?
-------------------------------------
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
-------------------------------------
<!-- Please describe the behavior or changes that are being added by this PR. -->

Adds the ability to test custom variable validations rules (introduced in Terraform v0.13) w/ user-defined assertions on the terraform command output. 

## Does this introduce a breaking change?
-------------------------------------
- [NO]

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information
-------------------------------------
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->